### PR TITLE
refactor: setup-1.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode/settings.json

--- a/setup-1.sh
+++ b/setup-1.sh
@@ -102,11 +102,11 @@ if ! command -v brew &> /dev/null; then
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" # > /dev/null 2>&1
     # Add Homebrew to PATH
     echo "Adding Homebrew to PATH"
-    echo >> ~/.zprofile
     echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
     eval "$(/opt/homebrew/bin/brew shellenv)"
+    brew update
     echo "Homebrew installed successfully ✅"
-elif [[ -x $(command -v brew) ]]; then
+else
     echo "Homebrew already installed, skipping 🦘"
 fi
 

--- a/setup-1.sh
+++ b/setup-1.sh
@@ -66,7 +66,7 @@ if [[ $confirm == "yes" || $confirm == "y" ]]; then
     # Enable commit signing using the generated SSH key
     if [[ -z $(git config --global user.signingkey || true) ]]; then
         echo "Enabling commit signing 🔏"
-        git config --global user.signingkey $(ssh-keygen -lf ~/.ssh/id_ed25519.pub | awk '{print $2}')
+        git config --global user.signingkey ~/.ssh/id_ed25519.pub
         echo "Commit signing enabled successfully ✅"
     else
         echo "Commit signing already enabled, skipping 🦘"
@@ -81,6 +81,15 @@ if [[ $confirm == "yes" || $confirm == "y" ]]; then
     else
         echo "Commit signing globally already enabled, skipping 🦘"
     fi
+fi
+
+# Enable autoSetupRemote
+if [[ -z $(git config --global push.autoSetupRemote || true) ]]; then
+    echo "Enabling push.autoSetupRemote 🔗"
+    git config --global push.autoSetupRemote true
+    echo "push.autoSetupRemote enabled successfully ✅"
+else
+    echo "push.autoSetupRemote already set, skipping 🦘"
 fi
 
 ############################

--- a/setup-1.sh
+++ b/setup-1.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 ############################
 # Xcode CLI install
@@ -15,7 +16,7 @@ if [[ ! -e "/Library/Developer/CommandLineTools/" ]]; then
         sleep 5
     done
     echo "Xcode CLI tools installed successfully ✅"
-elif [[ -e "/Library/Developer/CommandLineTools/" ]]; then
+else
     echo "Xcode CLI tools already installed, skipping 🦘"
 fi
 
@@ -24,7 +25,7 @@ fi
 ############################
 
 echo "Setting up git 🛠️"
-if [[ -z $(git config --global user.name) ]]; then
+if [[ -z $(git config --global user.name || true) ]]; then
     read -p "Enter name: " name
     git config --global user.name "$name"
     echo "Name set successfully ✅"
@@ -32,13 +33,15 @@ else
     echo "git global name already set, skipping 🦘"
 fi
 
-if [[ -z $(git config --global user.email) ]]; then
+if [[ -z $(git config --global user.email || true) ]]; then
     read -p "Enter email address: " email
     git config --global user.email "$email"
     echo "Email set successfully ✅"
 else
     echo "git global email already set, skipping 🦘"
 fi
+
+email=$(git config --global user.email)
 
 # Generate new SSH key
 if [[ ! -f ~/.ssh/id_ed25519 ]]; then
@@ -61,7 +64,7 @@ if [[ $confirm == "yes" || $confirm == "y" ]]; then
     echo "SSH key added to SSH agent successfully 🔒"
 
     # Enable commit signing using the generated SSH key
-    if [[ -z $(git config --global user.signingkey) ]]; then
+    if [[ -z $(git config --global user.signingkey || true) ]]; then
         echo "Enabling commit signing 🔏"
         git config --global user.signingkey $(ssh-keygen -lf ~/.ssh/id_ed25519.pub | awk '{print $2}')
         echo "Commit signing enabled successfully ✅"
@@ -70,8 +73,9 @@ if [[ $confirm == "yes" || $confirm == "y" ]]; then
     fi
 
     # Enable commit signing globally
-    if [[ -z $(git config --global commit.gpgSign) ]]; then
+    if [[ -z $(git config --global commit.gpgSign || true) ]]; then
         echo "Enabling commit signing globally 🌎"
+        git config --global gpg.format ssh
         git config --global commit.gpgSign true
         echo "Global commit signing enabled successfully ✅"
     else
@@ -84,7 +88,7 @@ fi
 ############################
 
 # Check if Homebrew is installed and install it if not
-if [[ ! command -v brew &> /dev/null ]]; then
+if ! command -v brew &> /dev/null; then
     echo "Installing Homebrew 🍺"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" # > /dev/null 2>&1
     # Add Homebrew to PATH
@@ -114,7 +118,7 @@ if [[ $SHELL != "/bin/zsh" ]]; then
     echo "Switching shell to zsh 🐚"
     chsh -s /bin/zsh
     echo "Shell switched to zsh successfully ✅"
-elif [[ $SHELL == "/bin/zsh" ]]; then
+else
     echo "Shell already set to zsh, skipping 🦘"
 fi
 

--- a/setup-1.sh
+++ b/setup-1.sh
@@ -104,6 +104,7 @@ if ! command -v brew &> /dev/null; then
     echo "Adding Homebrew to PATH"
     echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
     eval "$(/opt/homebrew/bin/brew shellenv)"
+    source .zprofile
     brew update
     echo "Homebrew installed successfully ✅"
 else
@@ -132,3 +133,5 @@ else
 fi
 
 echo "Setup complete! 🎉"
+echo ""
+echo "Run 'source ~/.zprofile' or open a new terminal for brew to be available."

--- a/setup-1.sh
+++ b/setup-1.sh
@@ -104,8 +104,6 @@ if ! command -v brew &> /dev/null; then
     echo "Adding Homebrew to PATH"
     echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
     eval "$(/opt/homebrew/bin/brew shellenv)"
-    source .zprofile
-    brew update
     echo "Homebrew installed successfully ✅"
 else
     echo "Homebrew already installed, skipping 🦘"


### PR DESCRIPTION
# Summary 

Improves error handling and user experience

## Changes made
- Added `set -euo pipefail` to the top of the script to ensure it exits on errors and treats unset variables as errors
- Updated all `git config` checks to append `|| true`, preventing the script from failing if the config is unset
- Added logic to enable `push.autoSetupRemote` globally if not already set
- Updated commit signing key setup to use the SSH public key file path directly, and ensured `gpg.format` is set to `ssh` for commit signing.
- Improved Homebrew installation check
- Simplified conditional branches for checking existing installations and configuration, making script output clearer and more consistent
- Added a final message to remind to source .zprofile or open a new terminal for Homebrew to be available