### PR TITLE
chore: remove zsh-history-substring-search

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -33,7 +33,6 @@ esac
 ############################
 source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-source /opt/homebrew/share/zsh-history-substring-search/zsh-history-substring-search.zsh
 
 ############################
 # Aliases

--- a/Brewfile
+++ b/Brewfile
@@ -30,7 +30,6 @@ brew 'tilt'
 brew 'woff2'
 brew 'yt-dlp'
 brew 'zsh-autosuggestions'
-brew 'zsh-history-substring-search'
 brew 'zsh-syntax-highlighting'
 
 # Apps


### PR DESCRIPTION
- Remove zsh-history-substring-search