### PR TITLE
fix: trust oh-my-posh and snyk taps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,6 @@
 # Taps
-tap "jandedobbeleer/oh-my-posh"
-tap "snyk/tap"
+tap "jandedobbeleer/oh-my-posh", trusted: true
+tap "snyk/tap", trusted: true
 
 # Binaries
 brew 'atuin'


### PR DESCRIPTION
Tap trust is a new feature that has shipped in Homebrew 6.0.0, causing Homebrew to refuse to load and valuate formula/cask code from any third‑party (non‑official) tap unless that tap or the specific formula has been explicitly trusted. 

This PR sets the trusted flag to true for both the `jandedobbeleer/oh-my-posh` and `snyk/tap` taps